### PR TITLE
Fixed a similarity score calculation bug in Chroma module

### DIFF
--- a/langchain/vectorstores/chroma.py
+++ b/langchain/vectorstores/chroma.py
@@ -30,7 +30,7 @@ def _results_to_docs_and_scores(results: Any) -> List[Tuple[Document, float]]:
     return [
         # TODO: Chroma can do batch querying,
         # we shouldn't hard code to the 1st result
-        (Document(page_content=result[0], metadata=result[1] or {}), result[2])
+        (Document(page_content=result[0], metadata=result[1] or {}), 1.0 - result[2])
         for result in zip(
             results["documents"][0],
             results["metadatas"][0],


### PR DESCRIPTION
The `_results_to_docs_and_scores()` function should have returned the similarity score (higher values indicating more similarity), but erroneously returned the distance (higher values indicating less similarity).


 @rlancemartin, @eyurtsev
